### PR TITLE
allow providing DRUPAL_BASE_URL as documented + menu_items has moved?

### DIFF
--- a/demo-frontend/nuxt.config.js
+++ b/demo-frontend/nuxt.config.js
@@ -33,7 +33,8 @@ export default {
 
   // drupal-ce config: https://github.com/drunomics/nuxt-module-drupal-ce
   'nuxtjs-drupal-ce': {
-    baseURL: 'http://lupus-nuxtjs-drupal-stack-example.ddev.site',
+    baseURL: process.env.DRUPAL_BASE_URL || 'http://lupus-nuxtjs-drupal-stack-example.ddev.site',
+    menuEndpoint: 'api/menu_items/$$$NAME$$$',
     // For authenticated requests via domain lupus-nuxtjs-drupal-stack-example.ddev.site
     useProxy: false,
     axios: {

--- a/demo-frontend/nuxt.config.js
+++ b/demo-frontend/nuxt.config.js
@@ -34,7 +34,6 @@ export default {
   // drupal-ce config: https://github.com/drunomics/nuxt-module-drupal-ce
   'nuxtjs-drupal-ce': {
     baseURL: process.env.DRUPAL_BASE_URL || 'http://lupus-nuxtjs-drupal-stack-example.ddev.site',
-    menuEndpoint: 'api/menu_items/$$$NAME$$$',
     // For authenticated requests via domain lupus-nuxtjs-drupal-stack-example.ddev.site
     useProxy: false,
     axios: {


### PR DESCRIPTION
Just gave this repo a spin and noticed two issues with the options:
- https://github.com/drunomics/nuxt-drupal-ce-example allows setting the backend url via env, however both repos fail to pick up the value if provided
- the /menu_items/main route seems to have moved to /api/menu_items/main?

